### PR TITLE
Drop callbacks if state is invalid.

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -45,6 +45,9 @@
         ++active;
         a.push(function(e, r) {
           --active;
+          if (error) {
+            return;
+          }
           if (e) {
             if (remaining) {
               // clearing remaining cancels subsequent callbacks

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -70,6 +70,19 @@ suite.addBatch({
     }
   },
 
+  "queue with multiple tasks where one errors": {
+    topic: function() {
+      queue()
+          .defer(function(callback) { process.nextTick(function() { callback(-1); }); })
+          .defer(function(callback) { process.nextTick(function() { callback(null, 'ok'); }); })
+          .await(this.callback);
+    },
+    "the first error is returned": function(error, results) {
+      assert.equal(error, -1);
+      assert.isNull(results);
+    }
+  },
+
   "queue with multiple synchronous tasks that error": {
     topic: function() {
       queue()


### PR DESCRIPTION
Hi Mike,

This fixes a small bug where, if one callback fails but a later one succeeds, the later callback attempts to write to results (now null).

There is a new test in queue-test which shows the error on master.
