### PR TITLE
an apparent off by 1 error

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -19,7 +19,7 @@
     if (!parallelism) parallelism = Infinity;
 
     function pop() {
-      while (popping = started < tasks.length && active < parallelism) {
+      while (popping = started < tasks.length && active <= parallelism) {
         var i = started++,
             t = tasks[i],
             a = slice.call(t, 1);


### PR DESCRIPTION
According to the documentation the `parallelism` variable represents the maximum number of concurrently running queue items but in practice it seemed off by 1.  I confirmed this by testing out a queue set to `queue(1)` which resulted in nothing running.

The edit I made should resolve this.
