### PR TITLE
Add queue.status.

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -73,6 +73,15 @@ function newQueue(parallelism) {
       callback = f, callbackAll = true;
       if (!waiting && !active) notify();
       return q;
+    },
+    status: function() {
+      return error == null ? {
+        waiting: waiting,
+        active: active,
+        ended: ended
+      } : {
+        error: error
+      };
     }
   };
 }


### PR DESCRIPTION
I’m not convinced it’s worth adding this, for the sake of keeping this library minimal, but here it is.

Note that if an error occurs, the internal `waiting` variable gets set to NaN, and I don’t think we’d want to expose this implementation detail. It might be nice for queue.status to still report the task statuses even when an error occurs (since if parallelism > 1, other active tasks will continue to run after the first error).