### PR TITLE
Avoid passing `arguments` outside of `defer` so that V8 does not deoptimize `defer`.

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -1,1 +1,0 @@
-export var slice = [].slice;

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,5 +1,3 @@
-import {slice} from "./array";
-
 var noabort = {};
 
 function Queue(size) {
@@ -20,8 +18,17 @@ Queue.prototype = queue.prototype = {
   defer: function(callback) {
     if (typeof callback !== "function" || this._call) throw new Error;
     if (this._error != null) return this;
-    var t = slice.call(arguments, 1);
+
+    var l = arguments.length;
+    var t = [];
+    if (l > 0) {
+      t = new Array(l - 1);
+      for (var i = 1; i < l; ++i) {
+        t[i - 1] = arguments[i];
+      }
+    }
     t.push(callback);
+
     ++this._waiting, this._tasks.push(t);
     poke(this);
     return this;


### PR DESCRIPTION
V8 will deoptimize functions that pass `arguments` outside of a function, which happen in `defer`.

Some discussion about it:

https://github.com/GoogleChrome/devtools-docs/issues/53#issuecomment-51941358
http://stackoverflow.com/a/29200041/87798

While this has not been a critical performance issue for me yet, it does put warning icons in the DevTools profiler, which is really distracting, and seems fairly straightforward to address, so I made the change here.