### PR TITLE
default parallelism should be 1, not Infinity

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -113,5 +113,5 @@ function maybeNotify(q) {
 }
 
 export default function queue(concurrency) {
-  return new Queue(arguments.length ? +concurrency : Infinity);
+  return new Queue(arguments.length ? +concurrency : 1);
 }


### PR DESCRIPTION
I think it would make more sense to use 1 as default parallelism.

The name "queue" also describes a data structure, and therefor suggests that tasks are executed one after the other. But with infinite parallelism, the default behavior is does not involve any such queuing. Instead everything just happens "at once", just as it would without using d3.queue.

I get that some people just use d3.queue to wait until a lot of things are done. But again, that's not what one might expect from something that's called "queue".

Also let's not forget about the real life queue, which is more realistically described as a single queue with lots of people waiting in line, than as an infinite number of queues with just one person in each.

![queue](http://getlevelten.com/sites/default/files/styles/900x450/public/content/blog/images/istock_000017920441small.jpg?itok=8VNc9Bje)